### PR TITLE
Sensor dout pin and fetch fixes

### DIFF
--- a/drivers/sensor/hx711/hx711.c
+++ b/drivers/sensor/hx711/hx711.c
@@ -399,7 +399,7 @@ static int hx711_init(const struct device *dev)
 	k_sem_init(&data->dout_sem, 1, 1);
 
 	/* Configure DOUT as input */
-	data->dout_gpio = cfg->sck_ctrl;
+	data->dout_gpio = cfg->dout_ctrl;
 	LOG_DBG("DOUT pin controller is %p, name is %s\n", data->dout_gpio, data->dout_gpio->name);
 	ret = gpio_pin_configure(data->dout_gpio, cfg->dout_pin, GPIO_INPUT | cfg->dout_flags);
 	if (ret != 0) {

--- a/drivers/sensor/hx711/hx711.c
+++ b/drivers/sensor/hx711/hx711.c
@@ -97,6 +97,7 @@ static int hx711_cycle(struct hx711_data *data)
 static int hx711_sample_fetch(const struct device *dev, enum sensor_channel chan)
 {
 	int ret = 0;
+	int interrupt_cfg_ret;
 	uint32_t count = 0;
 	int i;
 
@@ -138,9 +139,10 @@ static int hx711_sample_fetch(const struct device *dev, enum sensor_channel chan
 	data->reading = count;
 
 exit:
-	ret = gpio_pin_interrupt_configure(data->dout_gpio, cfg->dout_pin, GPIO_INT_EDGE_TO_INACTIVE);
-	if (ret != 0) {
+	interrupt_cfg_ret = gpio_pin_interrupt_configure(data->dout_gpio, cfg->dout_pin, GPIO_INT_EDGE_TO_INACTIVE);
+	if (interrupt_cfg_ret != 0) {
 		LOG_ERR("Failed to set dout GPIO interrupt");
+		ret = interrupt_cfg_ret;
 	}
 
 	return ret;


### PR DESCRIPTION
These are two fixes for bugs that caused some headache to me.

* Previously for some reason dout gpio was initiated with clk ctrl structure. This causes the data to never be ready as the clock is not pulled high
* Return value fix in hx711_sample_fetch, previously this function always returns 0, even if it fails (as long as gpio_pin_interrupt_configure after the exit label succeeds). This causes this function to succeed even if it fails to read dout.