### PR TITLE
Add sub-gram decimal point

### DIFF
--- a/drivers/sensor/hx711/hx711.c
+++ b/drivers/sensor/hx711/hx711.c
@@ -329,7 +329,7 @@ static int hx711_channel_get(const struct device *dev, enum sensor_channel chan,
 
 	switch (hx711_chan) {
 	case HX711_SENSOR_CHAN_WEIGHT: {
-		val->val1 = sensor_value_to_double(&data->slope) * (data->reading - data->offset);
+		sensor_value_from_double(val, sensor_value_to_double(&data->slope)  * (data->reading - data->offset));
 		return 0;
 	}
 	default:


### PR DESCRIPTION
In the `sensor_value` val1 represents the integer part of the value, with val2 representing the fractional part.

Previously val2 was unset, leaving us without decimal points and no sub-gram precision.