### PR TITLE
Driver logic fixups and additions

### DIFF
--- a/drivers/sensor/hx711/hx711.c
+++ b/drivers/sensor/hx711/hx711.c
@@ -366,6 +366,10 @@ static int hx711_channel_get(const struct device *dev, enum sensor_channel chan,
 		sensor_value_from_double(val, sensor_value_to_double(&data->slope)  * (data->reading - data->offset));
 		return 0;
 	}
+	case HX711_SENSOR_CHAN_RAW: {
+		val->val1 = data->reading;
+		return 0;
+	}
 	default:
 		return -ENOTSUP;
 	}

--- a/drivers/sensor/hx711/hx711.c
+++ b/drivers/sensor/hx711/hx711.c
@@ -611,7 +611,7 @@ int hx711_pm_ctrl(const struct device *dev, enum pm_device_action action)
 	case PM_DEVICE_ACTION_RESUME:
 		ret = avia_hx711_power(dev, HX711_POWER_ON);
 		break;
-	case PM_DEVICE_ACTION_TURN_OFF:
+	case PM_DEVICE_ACTION_SUSPEND:
 		ret = avia_hx711_power(dev, HX711_POWER_OFF);
 		break;
 	default:

--- a/drivers/sensor/hx711/hx711.c
+++ b/drivers/sensor/hx711/hx711.c
@@ -105,7 +105,7 @@ static int hx711_sample_fetch(const struct device *dev, enum sensor_channel chan
 {
 	int ret = 0;
 	int interrupt_cfg_ret;
-	uint32_t count = 0;
+	int32_t count = 0;
 	int i;
 
 	struct hx711_data *data = dev->data;
@@ -134,7 +134,7 @@ static int hx711_sample_fetch(const struct device *dev, enum sensor_channel chan
 		hx711_cycle(data);
 	}
 
-	count ^= 0x800000;
+	count = (count & 0x7FFFFF) - (count & 0x800000);
 	data->reading = count;
 
 #if defined(CONFIG_HX711_ENABLE_MEDIAN_FILTER) || defined(CONFIG_HX711_ENABLE_EMA_FILTER)

--- a/drivers/sensor/hx711/hx711.h
+++ b/drivers/sensor/hx711/hx711.h
@@ -32,6 +32,7 @@ enum hx711_attribute {
 
 enum hx711_channel {
 	HX711_SENSOR_CHAN_WEIGHT = SENSOR_CHAN_PRIV_START,
+	HX711_SENSOR_CHAN_RAW    = SENSOR_CHAN_PRIV_START + 1,
 };
 
 enum hx711_gain {


### PR DESCRIPTION
Some fixups and additions:

### Power management
`PM_DEVICE_ACTION_TURN_OFF` is only used by power domains. To correctly power down the sensor it needs to react to `PM_DEVICE_ACTION_SUSPEND`.

### Twos complement conversion
The sensor outputs the adc value as twos complement. Even though
it is given in the datasheets example code, performing a xor
with 0x800000 is not the correct way to convert the value.
See https://en.wikipedia.org/wiki/Two%27s_complement for details.

### Addition
* Added HX711_SENSOR_CHAN_RAW to get the raw adc output